### PR TITLE
[No ticket]: Fix SPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
             targets: ["AmityUIKit"]),
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/AmityCo/Amity-Social-Cloud-SDK-iOS-SwiftPM.git", .exactItem(Version(5, 32, 0))),
+        .package(url: "https://github.com/AmityCo/Amity-Social-Cloud-SDK-iOS-SwiftPM.git", exact: "5.32.0"),
         .package(url: "https://github.com/SnapKit/SnapKit.git", exact: "5.0.1")
     ],
     targets: [


### PR DESCRIPTION
When we build `Coach`, we see this warning in Xcode:

<img width="414" alt="Screenshot 2023-03-09 at 3 55 13 PM" src="https://user-images.githubusercontent.com/4141428/224157485-5842287f-e9d7-46e7-a2d9-af41f1b26081.png">

This change fixes the problem in our Amity fork's `Package.swift`.

After this change is merged, then I'll need to tag a new version and update the version in the `Package.swift` of `coach-ios`.