### PR TITLE
Hide unsupported features

### DIFF
--- a/UpstraUIKit/UpstraUIKit/Localization/AmityLocalizable.strings
+++ b/UpstraUIKit/UpstraUIKit/Localization/AmityLocalizable.strings
@@ -28,7 +28,7 @@
 "general_leave" = "Leave";
 "general_like" = "Like";
 "general_liked" = "Liked";
-"general_reply" = "Reply";
+"general_reply" = "Replo";
 "general_view_reply" = "View replies";
 "general_general" = "General";
 "general_anonymous" = "Anonymous";

--- a/UpstraUIKit/UpstraUIKit/Localization/AmityLocalizable.strings
+++ b/UpstraUIKit/UpstraUIKit/Localization/AmityLocalizable.strings
@@ -28,7 +28,7 @@
 "general_leave" = "Leave";
 "general_like" = "Like";
 "general_liked" = "Liked";
-"general_reply" = "Replo";
+"general_reply" = "Reply";
 "general_view_reply" = "View replies";
 "general_general" = "General";
 "general_anonymous" = "Anonymous";

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/General/Cell/AmityCommentView/AmityCommentView.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/General/Cell/AmityCommentView/AmityCommentView.swift
@@ -144,8 +144,7 @@ class AmityCommentView: AmityView {
         leadingAvatarImageViewConstraint.constant = layout.space.avatarLeading
         topAvatarImageViewConstraint.constant = layout.space.aboveAvatar
 
-        replyButton.isHidden = !replyEnabled
-        
+        replyButton.isHidden = !replyEnabled || !layout.shouldShowReplyButton()
     }
 
     @IBAction func displaynameTap(_ sender: Any) {

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/General/Cell/AmityCommentView/AmityCommentViewLayout.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/General/Cell/AmityCommentView/AmityCommentViewLayout.swift
@@ -49,6 +49,15 @@ extension AmityCommentView {
             }
         }
         
+        func shouldShowReplyButton() -> Bool {
+            switch type {
+            case .reply:
+                return false
+            default:
+                return true
+            }
+        }
+        
     }
     
 }

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/User Profile/Child/ViewController/AmityUserProfileHeaderViewController.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/User Profile/Child/ViewController/AmityUserProfileHeaderViewController.swift
@@ -211,6 +211,8 @@ class AmityUserProfileHeaderViewController: AmityViewController, AmityRefreshabl
         followingButton.attributedString.setTitle(string)
         followingButton.attributedString.setBoldText(for: [value])
         followingButton.setAttributedTitle()
+        // Setting these labels to hidden because we're not supporting followers at the moment
+        followingButton.isHidden = true
     }
     
     private func updateFollowerCount(with followerCount: Int) {
@@ -219,6 +221,8 @@ class AmityUserProfileHeaderViewController: AmityViewController, AmityRefreshabl
         followersButton.attributedString.setTitle(string)
         followersButton.attributedString.setBoldText(for: [value])
         followersButton.setAttributedTitle()
+        // Setting these labels to hidden because we're not supporting followers at the moment
+        followersButton.isHidden = true
     }
     
     private func updateFollowButton(with status: AmityFollowStatus) {
@@ -226,7 +230,8 @@ class AmityUserProfileHeaderViewController: AmityViewController, AmityRefreshabl
         case .accepted:
             followButton.isHidden = true
         case .pending:
-            followButton.isHidden = false
+            // Setting isHidden to true here because the following functionality is confusing for users
+            followButton.isHidden = true
             followButton.setTitle(AmityLocalizedStringSet.userDetailFollowButtonCancel.localizedString, for: .normal)
             followButton.setImage(AmityIconSet.Follow.iconFollowPendingRequest, position: .left)
             followButton.backgroundColor = .white
@@ -234,7 +239,8 @@ class AmityUserProfileHeaderViewController: AmityViewController, AmityRefreshabl
             followButton.layer.borderWidth = 1
             followButton.tintColor = AmityColorSet.secondary
         case .none:
-            followButton.isHidden = false
+            // Setting isHidden to true here because the following functionality is confusing for users
+            followButton.isHidden = true
             followButton.setTitle(AmityLocalizedStringSet.userDetailFollowButtonFollow.localizedString, for: .normal)
             followButton.setImage(AmityIconSet.iconAdd, position: .left)
             followButton.backgroundColor = AmityColorSet.primary


### PR DESCRIPTION
There are two features that either don't work or are confusing to users that we're hiding in this change.

* Replies to Replies is not a supported feature by Amity, so we shouldn't have a button that makes it look like it is.
* The "Follow" feature only works with a user's individual timeline, but very few users actually use that, so this feels like a broken feature to users.


[Reference doc](https://docs.google.com/document/d/1nIOtfzcMgwibksp4x86kb13szl47IDTpY1nFJE1bInM/edit)