### PR TITLE
Make anonymous communities unable to view member list

### DIFF
--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community List/Model/AmityCommunitiesModel.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community List/Model/AmityCommunitiesModel.swift
@@ -11,7 +11,9 @@ import AmitySDK
 
 struct AmityCommunityModel {
     public static let commentsDisabledKey = "isCommentingDisabled"
-    public static let commentsHiddenKey = "areCommentsHidden" 
+    public static let commentsHiddenKey = "areCommentsHidden"
+    public static let anonymousKey = "isAnonymous"
+    
     let communityId: String
     let description: String
     let displayName: String

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community Profile/ViewController/Child/AmityCommunityProfileHeaderViewController.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community Profile/ViewController/Child/AmityCommunityProfileHeaderViewController.swift
@@ -119,8 +119,8 @@ final class AmityCommunityProfileHeaderViewController: UIViewController {
     private func updateMemberLabel(community: AmityCommunityModel?) {
         let isAnonymous = community?.metadata?[AmityCommunityModel.anonymousKey] as? Bool ?? false
         
-        if !isAnonymous && community != nil {
-            let memberCount = community!.membersCount
+        if !isAnonymous, let community {
+            let memberCount = community.membersCount
             var  format = memberCount == 1 ? AmityLocalizedStringSet.Unit.memberSingular.localizedString : AmityLocalizedStringSet.Unit.memberPlural.localizedString
             format = format.replacingOccurrences(of: " ", with: "\n") // adjust a format of localized string... "%@ members" -> "%@\nmembers"
             let value = memberCount.formatUsingAbbrevation()

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community Profile/ViewController/Child/AmityCommunityProfileHeaderViewController.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community Profile/ViewController/Child/AmityCommunityProfileHeaderViewController.swift
@@ -48,7 +48,7 @@ final class AmityCommunityProfileHeaderViewController: UIViewController {
         setupBadgeView()
         setupSubTitleLabel()
         updatePostLabel(postCount: 0)
-        updateMemberLabel(memberCount: 0)
+        updateMemberLabel(community: nil)
         setupDescription()
         setupActionButton()
         setupPendingPosts()
@@ -116,19 +116,29 @@ final class AmityCommunityProfileHeaderViewController: UIViewController {
         postLabel.attributedText = attribute
     }
     
-    private func updateMemberLabel(memberCount: Int) {
-        var  format = memberCount == 1 ? AmityLocalizedStringSet.Unit.memberSingular.localizedString : AmityLocalizedStringSet.Unit.memberPlural.localizedString
-        format = format.replacingOccurrences(of: " ", with: "\n") // adjust a format of localized string... "%@ members" -> "%@\nmembers"
-        let value = memberCount.formatUsingAbbrevation()
-        let string = String.localizedStringWithFormat(format, value)
+    private func updateMemberLabel(community: AmityCommunityModel?) {
+        let isAnonymous = community?.metadata?[AmityCommunityModel.anonymousKey] as? Bool ?? false
         
-        let attribute = NSMutableAttributedString(string: string,
-                                                  attributes: [.font : AmityFontSet.body,
-                                                               .foregroundColor: AmityColorSet.base.blend(.shade1)])
-        let range = NSString(string: string).range(of: value)
-        attribute.addAttributes([.font : AmityFontSet.bodyBold,
-                                 .foregroundColor: AmityColorSet.base], range: range)
-        memberLabel.attributedText = attribute
+        if !isAnonymous && community != nil {
+            let memberCount = community!.membersCount
+            var  format = memberCount == 1 ? AmityLocalizedStringSet.Unit.memberSingular.localizedString : AmityLocalizedStringSet.Unit.memberPlural.localizedString
+            format = format.replacingOccurrences(of: " ", with: "\n") // adjust a format of localized string... "%@ members" -> "%@\nmembers"
+            let value = memberCount.formatUsingAbbrevation()
+            let string = String.localizedStringWithFormat(format, value)
+            
+            let attribute = NSMutableAttributedString(string: string,
+                                                      attributes: [.font : AmityFontSet.body,
+                                                                   .foregroundColor: AmityColorSet.base.blend(.shade1)])
+            let range = NSString(string: string).range(of: value)
+            attribute.addAttributes([.font : AmityFontSet.bodyBold,
+                                     .foregroundColor: AmityColorSet.base], range: range)
+            memberLabel.attributedText = attribute
+            memberLabel.isHidden = false
+        } else {
+            memberLabel.isHidden = true
+        }
+        
+        separatorView.isHidden = memberLabel.isHidden
     }
     
     private func setupDescription() {
@@ -181,7 +191,7 @@ final class AmityCommunityProfileHeaderViewController: UIViewController {
         displayNameLabel.text = community.displayName
         descriptionLabel.text = community.description
         descriptionLabel.isHidden = community.description == ""
-        updateMemberLabel(memberCount: Int(community.membersCount))
+        updateMemberLabel(community: community)
         categoryLabel.text = community.category
         privateBadgeImageView.isHidden = community.isPublic
         officialBadgeImageView.isHidden = !community.isOfficial

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community Profile/ViewController/Parent/AmityCommunityProfilePageViewController.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community Profile/ViewController/Parent/AmityCommunityProfilePageViewController.swift
@@ -178,8 +178,11 @@ extension AmityCommunityProfilePageViewController: AmityCommunityProfileScreenVi
                 analyticsSource: .communityProfile
             )
         case .member:
-            let vc = AmityCommunityMemberSettingsViewController.make(community: community.object)
-            navigationController?.pushViewController(vc, animated: true)
+            let isAnonymous = community.metadata?[AmityCommunityModel.anonymousKey] as? Bool ?? false
+            if !isAnonymous {
+                let vc = AmityCommunityMemberSettingsViewController.make(community: community.object)
+                navigationController?.pushViewController(vc, animated: true)
+            }
         case .settings:
             let vc = AmityCommunitySettingsViewController.make(communityId: community.communityId)
             navigationController?.pushViewController(vc, animated: true)


### PR DESCRIPTION
B2B has a requirement for anonymous communities, which are just communities that have the member list inaccessible.

This PR turns off the member list button and hides the label that is normally the member list button (so as not to appear as a bug).

This has been tested manually.

Not Anonymous:
![image](https://user-images.githubusercontent.com/10712840/232138729-2946b5d9-4a05-4efd-853e-3ca186afeb47.png)

Anonymous:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/10712840/232139448-6ea7e873-c761-4e18-b175-3b6f43178aee.png">
