### PR TITLE
Hide create community buttons for B2B users

### DIFF
--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community List/Scenes/My Community/ViewController/AmityMyCommunityViewController.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Community List/Scenes/My Community/ViewController/AmityMyCommunityViewController.swift
@@ -84,10 +84,14 @@ public final class AmityMyCommunityViewController: AmityViewController, Indicato
     // MARK: - Setup views
     private func setupView() {
         title = AmityLocalizedStringSet.Home.homeMe.localizedString
+        
         if communityCreationButtonVisible() {
             let rightItem = UIBarButtonItem(image: AmityIconSet.iconAdd, style: .plain, target: self, action: #selector(createCommunityTap))
             rightItem.tintColor = AmityColorSet.base
             navigationItem.rightBarButtonItem = rightItem
+            createButton.isHidden = false
+        } else {
+            createButton.isHidden = true
         }
     }
     
@@ -98,6 +102,13 @@ public final class AmityMyCommunityViewController: AmityViewController, Indicato
         if let overrideVisible = AmityUIKitManagerInternal.shared.env["amity_uikit_social_community_creation_button_visible"] as? Bool {
             visible = overrideVisible
         }
+        
+        if let currentUserMetadata = AmityUIKitManagerInternal.shared.client.currentUser?.object?.metadata,
+            let businessType = currentUserMetadata[AmityUserModel.businessTypeKey] as? String,
+            businessType == "B2B" {
+            visible = false
+        }
+        
         return visible
     }
     

--- a/UpstraUIKit/UpstraUIKit/Modules/Comunity/Newsfeed/Empty View/AmityNewsfeedEmptyView.swift
+++ b/UpstraUIKit/UpstraUIKit/Modules/Comunity/Newsfeed/Empty View/AmityNewsfeedEmptyView.swift
@@ -53,6 +53,12 @@ final class AmityNewsfeedEmptyView: AmityView {
         createCommunityButton.setTitleColor(AmityColorSet.primary, for: .normal)
         createCommunityButton.setTitleColor(AmityColorSet.primary.blend(.shade2), for: .disabled)
         createCommunityButton.isEnabled = Reachability.shared.isConnectedToNetwork
+        
+        if let currentUserMetadata = AmityUIKitManagerInternal.shared.client.currentUser?.object?.metadata,
+            let businessType = currentUserMetadata[AmityUserModel.businessTypeKey] as? String,
+            businessType == "B2B" {
+            createCommunityButton.isHidden = true
+        }
     }
     
     func setNeedsUpdateState() {


### PR DESCRIPTION
## Motivation
The B2B team doesn't want to have users creating any communities, private nor public, so we're disabling the option.

## Changes
* Removed the two locations "Create new community" buttons were displayed conditionally based on user business type.

## Testing
Tested manually.

## Pictures
### Before
![image](https://user-images.githubusercontent.com/10712840/232917364-3032af7f-970f-49ca-8a4a-75d213964382.png)
![image](https://user-images.githubusercontent.com/10712840/232917381-9486a68f-d975-4a80-b93c-c2b098924f9e.png)


### After
![image](https://user-images.githubusercontent.com/10712840/232917322-de687148-f251-4d75-8299-8fb52572b1f1.png)
![image](https://user-images.githubusercontent.com/10712840/232917342-fa02b894-69fe-4197-9b52-0c0a584e4fde.png)
